### PR TITLE
Fix manual release creation refspec error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -483,6 +483,7 @@ jobs:
           TAG: ${{ needs.prepare-release-tag.outputs.release_tag }}
         run: |
           set -euo pipefail
+          git tag "$TAG"
           git push origin "$TAG" || { sleep 2; git push origin "$TAG"; }
 
       - name: Create release with generated notes + discussion


### PR DESCRIPTION
This PR modifies the `ci.yml` workflow to create a git tag locally before attempting to push it to the remote repository. This prevents the `error: src refspec ... does not match any` error during manual release creation.

---
*PR created automatically by Jules for task [7318146716005405636](https://jules.google.com/task/7318146716005405636) started by @arran4*