### PR TITLE
ci: fix "tag already exists" error in release jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -449,7 +449,7 @@ jobs:
           go-version-file: go.mod
       - name: Tag commit for release (workflow_dispatch)
         if: ${{ github.event_name == 'workflow_dispatch' && startsWith(inputs.mode, 'release-') }}
-        run: git tag ${{ needs.prepare-release-tag.outputs.release_tag }}
+        run: git tag -f ${{ needs.prepare-release-tag.outputs.release_tag }}
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
@@ -483,8 +483,8 @@ jobs:
           TAG: ${{ needs.prepare-release-tag.outputs.release_tag }}
         run: |
           set -euo pipefail
-          git tag "$TAG"
-          git push origin "$TAG" || { sleep 2; git push origin "$TAG"; }
+          git tag -f "$TAG"
+          git push -f origin "$TAG" || { sleep 2; git push -f origin "$TAG"; }
 
       - name: Create release with generated notes + discussion
         env:


### PR DESCRIPTION
Updated the git tag and git push commands in `.github/workflows/ci.yml` to use the `-f` flag, forcing the creation and push. This resolves the `fatal: tag 'v0.0.6' already exists` error encountered during the GoReleaser and manual-gh-release jobs.

---
*PR created automatically by Jules for task [5564691682055386560](https://jules.google.com/task/5564691682055386560) started by @arran4*