### PR TITLE
ci: prevent prepare-next-version-pr job from failing on empty commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -555,6 +555,7 @@ jobs:
           git checkout -b "$BRANCH"
 
           git add -A
+          if git diff --staged --quiet; then echo "No changes"; exit 0; fi
           git commit -m "Prepare next development iteration $NEXT_VERSION"
           git push -u origin "$BRANCH"
           gh pr create --title "Prepare next development iteration $NEXT_VERSION" --body "Automated PR for next iteration." --base main --head "$BRANCH"


### PR DESCRIPTION
Fixes a CI failure in the "Prepare next development iteration PR" step where `git commit` would fail if there were no changes to commit. Added a check `if git diff --staged --quiet; then echo "No changes"; exit 0; fi` to prevent this error.

---
*PR created automatically by Jules for task [8031213816518481133](https://jules.google.com/task/8031213816518481133) started by @arran4*